### PR TITLE
Fix/trivials

### DIFF
--- a/src/main/MainRunner.ts
+++ b/src/main/MainRunner.ts
@@ -40,14 +40,14 @@ export const createMainWindow = async (mainWindow: BrowserWindow): Promise<Brows
     mainWindow.setAlwaysOnTop(false)
   })
 
+  // Initialize IPC Communication
+  IPCs.initialize(mainWindow)
+
   if (Constants.IS_DEV_ENV) {
     await mainWindow.loadURL(Constants.APP_INDEX_URL_DEV)
   } else {
     await mainWindow.loadFile(Constants.APP_INDEX_URL_PROD)
   }
-
-  // Initialize IPC Communication
-  IPCs.initialize(mainWindow)
 
   return mainWindow
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,12 +12,12 @@ app.on('ready', async () => {
   }
   macOSDisableDefaultMenuItem()
 
-  mainWindow = createMainWindow(mainWindow)
+  mainWindow = await createMainWindow(mainWindow)
 })
 
-app.on('activate', () => {
+app.on('activate', async () => {
   if (!mainWindow) {
-    mainWindow = createMainWindow(mainWindow)
+    mainWindow = await createMainWindow(mainWindow)
   }
 })
 


### PR DESCRIPTION
fix trivials

1
Ensure asynchronous execution of window creation
2
Refactor initialization sequence for clarity

## Summary
This PR reorders the initialization sequence in the `createMainWindow` function, moving the IPC Communication initialization block to execute before the environment-specific main window loading logic.

## Changes
- IPC Communication initialization is now performed immediately after the main window creation and basic setup, but before the loading of URL or files based on the environment.

## Rationale
The adjustment ensures that the IPC handlers are set up in a consistent state before any content loading begins, which is essential for handling events that might occur early in the application lifecycle, particularly in a production environment.

## Impact
No immediate impact on existing functionality is expected. However, this change can prevent potential race conditions or initialization issues that may arise during the application scaling or further development.


## Summary
This PR fixes potential race conditions in the app's lifecycle events by ensuring that `createMainWindow` is awaited, thus fully initializing the mainWindow before usage.

## Changes
- Added `await` keyword to the `createMainWindow` function calls within the 'ready' and 'activate' event handlers.

## Rationale
Previously, `createMainWindow` was called without `await`, leading to scenarios where `mainWindow` could potentially be interacted with before being fully initialized. This was particularly problematic during the 'activate' event, which may fire when the app is reactivated from the dock or taskbar.

## Impact
The addition of `await` ensures that the application's main window is ready before it is shown or interacted with, preventing errors that may occur due to uninitialized state. This change is critical for maintaining a stable application lifecycle, especially when dealing with asynchronous operations in Electron's main process.


by chatgptplus